### PR TITLE
README: Update link to point to NanoSat MO site

### DIFF
--- a/interfaces/README.md
+++ b/interfaces/README.md
@@ -1,4 +1,4 @@
 # MOWebViewer
 A HTML/JS viewer for CCSDS MO Services
 
-Visit the [website](https://esa.github.io/mo.viewer.web/) to browse the services.
+Visit the [website](https://nanosat-mo-framework.github.io/interfaces/index.html) to browse the services.


### PR DESCRIPTION
I updated this link in the README since it appears that the interfaces
are more up to date on nanosat-mo-framework.github.io compared to what
is currently on the ESA website. Not sure if that is correct, but was a
quick change, so opening this PR just in case.