### PR TITLE
docs: Further subdivision of documentation

### DIFF
--- a/docs.html
+++ b/docs.html
@@ -102,38 +102,31 @@
 		<div class="container">
 		  <div class="row">
 			<div class="col-lg-12">
-			  <h2>Documentation</h2>
-			  <br>
-			  <p>A quick introduction on the NanoSat MO Framework is available: <a href="https://en.wikipedia.org/wiki/NanoSat_MO_Framework">Wikipedia</a></p>
-			  <p>The documentation of the NanoSat MO Framework is available: <a href="https://github.com/esa/nanosat-mo-framework/tree/dev/sdk/sdk-package/src/main/resources/docs">here</a></p>
-			  <p>The interfaces of the NanoSat MO Framework are available: <a href="interfaces/index.html">Interfaces page</a></p>
-			  <p>There is also online documentation hosted on: <a href="https://nanosat-mo-framework.readthedocs.io/en/latest/">"Read the Docs" website</a></p>
-			  <br><br>
-			  <a href="https://nanosat-mo-framework.readthedocs.io/en/latest/">
-				<img src="img/readthedocs_logo-wordmark-dark.svg" height="100%" width="100%" style="max-width: 300px; max-height: 60px;">
-			  </a>
-			</div>
-		  </div>
-		</div>
-	</section>
-
-	<section class="jumbotron jumbotron-fluid text-center jumbo-white-color">
-		<div class="container">
-		  <div class="row">
-			<div class="col-lg-3">
-			</div>
-			<div class="col-lg-6">
-			  <h2>Literature</h2>
-			  <br>
-			  <p>PhD Dissertation: <a href="https://www.researchgate.net/publication/321825076">A Software Framework for Nanosatellites based on CCSDS Mission Operations Services with Reference Implementation for ESA's OPS-SAT Mission</a></p>
-			  <p>
-				<a href="http://arc.aiaa.org/doi/pdf/10.2514/6.2016-2624">NanoSat MO Framework: Achieving On-board Software Portability</a>
-				<br><a href="https://www.researchgate.net/publication/275639081_CCSDS_Mission_Operations_Services_on_OPS-SAT">CCSDS Mission Operations Services on OPS-SAT</a>
-				<br><a href="http://arc.aiaa.org/doi/pdf/10.2514/6.2016-5301">OPS-SAT Experiments’ Software Management with the NanoSat MO Framework</a>
-				<br><a href="https://www.researchgate.net/publication/316588347_NanoSat_MO_Framework_When_OBSW_turns_into_apps">NanoSat MO Framework: When OBSW turns into apps</a>
-				<br><a href="https://www.researchgate.net/publication/320267505_NanoSat_MO_Framework_Drill_down_your_nanosatellite%27s_platform_using_CCSDS_Mission_Operations_services">NanoSat MO Framework: Drill down your nanosatellite’s platform using CCSDS Mission Operations services</a>
-				<br><a href="https://nanosat-mo-framework.readthedocs.io/en/latest/">ReadTheDocs documentation and tutorial</a>
-			  </p>
+			  <h1>Documentation</h1>
+        <br>
+        <br>
+        <br>
+        <h3>NanoSat MO Framework</h3>
+        <p><strong><a href="https://en.wikipedia.org/wiki/NanoSat_MO_Framework">Overview</a></strong></p>
+        <p><strong><a href="https://github.com/esa/nanosat-mo-framework/tree/dev/sdk/sdk-package/src/main/resources/docs">SDK</a></strong></p>
+        <p><strong><a href="interfaces/index.html">Interfaces</a></strong></p>
+        <p><strong><a href="https://nanosat-mo-framework.readthedocs.io/en/latest/">Read the Docs</a></strong></p>
+        <br>
+        <br>
+        <br>
+        <h3>Literature</h3>
+        <br>
+        <h4>PhD Dissertation</h4>
+        <p><a href="https://www.researchgate.net/publication/321825076">A Software Framework for Nanosatellites based on CCSDS Mission Operations Services with Reference Implementation for ESA's OPS-SAT Mission</a></p>
+        <br>
+        <h4>AIAA</h4>
+			  <p><a href="http://arc.aiaa.org/doi/pdf/10.2514/6.2016-2624">NanoSat MO Framework: Achieving On-board Software Portability</a></p>
+				<p><a href="http://arc.aiaa.org/doi/pdf/10.2514/6.2016-5301">OPS-SAT Experiments’ Software Management with the NanoSat MO Framework</a></p>
+        <br>
+        <h4>ResearchGate</h4>
+				<p><a href="https://www.researchgate.net/publication/275639081_CCSDS_Mission_Operations_Services_on_OPS-SAT">CCSDS Mission Operations Services on OPS-SAT</a></p>
+				<p><a href="https://www.researchgate.net/publication/316588347_NanoSat_MO_Framework_When_OBSW_turns_into_apps">NanoSat MO Framework: When OBSW turns into apps</a></p>
+				<p><a href="https://www.researchgate.net/publication/320267505_NanoSat_MO_Framework_Drill_down_your_nanosatellite%27s_platform_using_CCSDS_Mission_Operations_services">NanoSat MO Framework: Drill down your nanosatellite’s platform using CCSDS Mission Operations services</a></p>
 			</div>
 		  </div>
 		</div>


### PR DESCRIPTION
@CesarCoelho 

I had an idea about adding additional organization to the documentation page to hopefully increase parseability.

**Before:**
![Screenshot from 2020-12-19 16-42-39](https://user-images.githubusercontent.com/1130872/102693244-9c5eb480-4219-11eb-82ad-f9dd27b757c9.png)

**After:**
![Screenshot from 2020-12-19 16-42-49](https://user-images.githubusercontent.com/1130872/102693300-e5166d80-4219-11eb-8f6c-236d1ab1df31.png)
